### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # HYBImageCliped
 开源高效处理圆角的扩展，包括UIImageView、UIView、UIButton、UIImage的扩展API，可根据图片颜色生成图片带任意圆角，可给UIButton根据不同状态处理图片。所有生成图片都不会引起离屏渲染且不会引起blended color layer、misaligned image等。
 
-#概述
+# 概述
 
 **开源项目名称**：HYBImageCliped  
 **当前版本：**2.2.3  
 **项目用途：**可给任意继承UIView的控件添加任意多个圆角、可根据颜色生成图片且可带任意个圆角、给UIButton设置不同状态下的图片且可带任意圆角、给UIImageView设置任意图片，支持带圆角或者直接生成圆形。上述功能都不会造成离屏渲染。
 
-#版本变化
+# 版本变化
 
-###Version 2.2.3
+### Version 2.2.3
 
 * 增加对自动布局的支持
 
-###Version 2.2.2
+### Version 2.2.2
 
 * 增加刷新缓存的功能，用于解决view的宽高需要动态变化这种需求
 
@@ -22,11 +22,11 @@
 @property (nonatomic, assign) BOOL hyb_shouldRefreshCache;
 ```
 
-###Version 2.2.1
+### Version 2.2.1
 
 * fix单圆角或者双圆角也显示成四个圆角的bug
 
-###Version 2.2.0
+### Version 2.2.0
 
 * 修改添加边框颜色的方法，并缓存
 * 增加单边框的API
@@ -42,18 +42,18 @@
 
 优化后的多了好多的控件，所以效果没有达到60~
 
-###Version 2.1.1
+### Version 2.1.1
 
 * 优化内存，及时释放不用的图片
 
-###Version 2.1.0
+### Version 2.1.0
 
 * 增加带圆角的图片可以设置边框
 * 增加图片缓存到内存功能、异步读取、保存图片功能、异步清除缓存功能
 
 ![image](http://www.henishuo.com/wp-content/uploads/2016/04/QQ20160407-0@2x-1-e1460027780352.png)
 
-###Version 2.0.0
+### Version 2.0.0
 
 * 将UIImageView扩展中的API全部移至UIView扩展，这样可以直接使用更轻量的UIView来显示图片，而不需要UIImageView。同时还可以兼容使用UImageView的同学
 * 增加几个方便生成图片的API
@@ -65,33 +65,33 @@
 
 详情查看：[Version2.0.0新增API](#Version2.0.0)
 
-###Version 1.1.1
+### Version 1.1.1
 
 * fix bug
 * 优化内存
 
-###Version 1.1.0
+### Version 1.1.0
 
 * 增加剪裁的图片缓存管理类HYBImageClipedManager，用于解决缓存到内存引起内存增长很快的问题。详情查看**[HYBImageClipedManager](#HYBImageClipedManager)**
 
 
-###Version 1.0.1
+### Version 1.0.1
 
 * fix文档未上传的bug
 * 去掉不相关的注释
 * 增加demo
 
-#Screenshot
+# Screenshot
 
 ![image](http://www.henishuo.com/wp-content/uploads/2016/04/cliped.gif)
 
-#裁剪花费的时间
+# 裁剪花费的时间
 
 ![image](http://www.henishuo.com/wp-content/uploads/2016/04/QQ20160402-0@2x-e1459561717603.png)
 
 正常图片裁剪所花费的时间是挺小的，但是当图片过大时，花费时间也会越多。但是，裁剪前滚动列表是非常明显地卡，裁剪后滚动是明显的流畅。对于图片列表这个demo中，裁剪后FPS能平均在58左右，基本没有感觉到卡。
 
-#如何使用
+# 如何使用
 
 在使用之前，先引入头文件：
 
@@ -99,7 +99,7 @@
 #import "HYBImageCliped.h"
 ```
 
-##<a name="HYBImageClipedManager"></a>HYBImageClipedManager
+## <a name="HYBImageClipedManager"></a>HYBImageClipedManager
 
 此类用于处理图片缓存到本地，解决内存增长问题。只有以下几个API，分别是读取图片、存储图片、获取缓存大小、清空缓存：
 
@@ -134,7 +134,7 @@
 + (void)clearClipedImagesCache;
 ```
 
-##UIImage+HYBImageCliped
+## UIImage+HYBImageCliped
 
 目前提供了以下几种类型的API：
 
@@ -144,7 +144,7 @@
 * 生成带任意圆角的图片
 * 直接生成圆形图片
 
-###<a name="Version2.0.0">2.0.0新增：</a>增加添加图片边框属性
+### <a name="Version2.0.0">2.0.0新增：</a>增加添加图片边框属性
 
 ```
 #pragma mark - 边框相关属属性，仅对生成圆形图片和矩形图片有效
@@ -166,7 +166,7 @@
 @property (nonatomic, strong) UIColor *hyb_pathColor;
 ```
 
-###根据颜色生成图片
+### 根据颜色生成图片
 
 下面是注释去掉后的API，可以根据颜色生成指定大小的图片，也可以设定生成带圆角的图片，当有圆角时，可以指定背景颜色，以处理图层混合问题：
 
@@ -181,7 +181,7 @@
                 backgroundColor:(UIColor *)backgroundColor;
 ```
 
-###单纯放大或者缩小图片
+### 单纯放大或者缩小图片
 
 这里注释已去掉，参数一是放大或者缩小图片至targetSize，参数二是表示是否要等比例放大或者缩小。当图片的宽、高比与targetSize的宽、高比差不多时，可以使用等比例；当相关很大时，如果使用等比例，将看不到一部分内容。
 
@@ -190,7 +190,7 @@
                isEqualScale:(BOOL)isEqualScale;
 ```
 
-###直接生成带四个圆角的图片
+### 直接生成带四个圆角的图片
 
 当有圆角时，默认背景颜色为白色。为了解决图层混合所带来的性能问题，若白色与控件的背景颜色不一样，请手动指定背景颜色，以生成最适合场景的图片：
 
@@ -206,7 +206,7 @@
                cornerRadius:(CGFloat)cornerRadius;
 ```
 
-###生成带任意圆角的图片
+### 生成带任意圆角的图片
 
 图片也可以生成带任意圆角的，比如要生成上左、上右这两个圆角，可以这么写UIRectCornerTopLeft | UIRectCornerTopRight，中间直接使用 | 来连接即可：
 
@@ -224,7 +224,7 @@
                     corners:(UIRectCorner)corners;
 ```
 
-###直接生成圆形图片
+### 直接生成圆形图片
 
 在App中有很多是要显示成圆形的，因此使用下面的API来直接生成圆形图片是很方便的：
 
@@ -238,14 +238,14 @@
 - (UIImage *)hyb_clipCircleToSize:(CGSize)targetSize;
 ```
 
-##UIButton+HYBImageCliped
+## UIButton+HYBImageCliped
 
 对于UIButton，目前提供了两种API：
 
 * 根据状态设置图片
 * 根据状态设置背景图片
 
-###根据状态设置图片
+### 根据状态设置图片
 
 这两个API只差一个参数targetSize，如果控件已经是明确的大小，可以直接使用不带targetSize参数的API。如果控件大小在设置图片前不确定，请手动明确指定要生成的图片的大小：
 
@@ -262,7 +262,7 @@
         isEqualScale:(BOOL)isEqualScale;
 ```
 
-###根据状态设置背景图片
+### 根据状态设置背景图片
 
 按钮是只可以有多种状态的，可设置图片，自然也可设置背景图片：
 
@@ -279,7 +279,7 @@
                   isEqualScale:(BOOL)isEqualScale;
 ```
 
-##UIView+HYBImageCliped
+## UIView+HYBImageCliped
 
 支持给任意视图添加带任意个圆角。使用起来也非常简单，看注释中的API介绍，带有小例子。如果有多个圆角，通过UIRectCornerTopLeft |UIRectCornerBottomRight这样来设置，中间用 | 连接，表示按位与的意思：
 
@@ -306,7 +306,7 @@
 - (void)hyb_addCornerRadius:(CGFloat)cornerRadius;
 ```
 
-##~~UIImageView+HYBImageCliped~~
+## ~~UIImageView+HYBImageCliped~~
 
 2.0版本之后，已经添加至**UIView+HYBImageCliped**
 
@@ -319,7 +319,7 @@
 
 每个API后面都带有一个闭包回调，在剪裁完成时，会回传，外部可以根据需求处理。因为裁剪是异步去处理的，所以只好通过闭包回调！
 
-###将图片裁剪成指定大小（只是单纯地缩放）
+### 将图片裁剪成指定大小（只是单纯地缩放）
 
 如果不需要添加任何圆角，只是想解决图片过大，与控件本身相差太大而千万像素不对齐的问题，可以直接使用下面的API：
 
@@ -331,7 +331,7 @@
 - (UIImage *)hyb_setImage:(id)image isEqualScale:(BOOL)isEqualScale onCliped:(HYBClipedCallback)callback;
 ```
 
-###直接生成圆形图像
+### 直接生成圆形图像
 
 在开发中，有很多是直接显示圆形头像、圆形图片的，下面的API可以直接生成：
 
@@ -349,7 +349,7 @@
                        onCliped:(HYBClipedCallback)callback;
 ```
 
-###生成四个带圆角图片来填充
+### 生成四个带圆角图片来填充
 
 如果显示带四个圆角，可以直接使用下面的API，高效生成带圆角的且与控件大小一致的图片来填充：
 
@@ -376,7 +376,7 @@
                  onCliped:(HYBClipedCallback)callback;
 ```
 
-###生成任意圆角图片来填充
+### 生成任意圆角图片来填充
 
 如果出现特殊的场景，需要生成三个圆角之类的特殊情况，或者生成上左、下左圆角或者生成上右、下右这样的组合情况时，可以通过下面的API来生成：
 
@@ -415,7 +415,7 @@
                  onCliped:(HYBClipedCallback)callback;
 ```
 
-#网络下载图片处理
+# 网络下载图片处理
 
 下面是一段通过SDWebImage来实现的异步下载图片然后剪裁后再显示的代码：
 
@@ -444,7 +444,7 @@ if (model.clipedImage) {
 
 为了防止SDWebImage每次读取本地的，做了个判断，将裁剪后的图片放到模型中，下次直接使用即可！
 
-#根据颜色生成图片使用
+# 根据颜色生成图片使用
 
 ```
 UIImageView *colorImageView = [[UIImageView alloc] init];
@@ -453,7 +453,7 @@ colorImageView.frame = CGRectMake(200, 200, 80, 100);
 colorImageView.image = [UIImage hyb_imageWithColor:[UIColor greenColor] toSize:CGSizeMake(80, 100) cornerRadius:20];
 ```
 
-#按钮使用
+# 按钮使用
 
 ```
 UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
@@ -464,7 +464,7 @@ button.backgroundColor = [UIColor whiteColor];
 [button hyb_setImage:@"bimg5.jpg" forState:UIControlStateHighlighted cornerRadius:40 isEqualScale:NO];
 ```
 
-#UIImageView使用
+# UIImageView使用
 
 生成圆形图片：
 
@@ -474,7 +474,7 @@ button.backgroundColor = [UIColor whiteColor];
 }];
 ```
 
-#任意圆角
+# 任意圆角
 
 ```
 UIView *view1 = [[UIView alloc] initWithFrame:CGRectMake(10, 100, 80, 80)];
@@ -500,7 +500,7 @@ view3.backgroundColor = [UIColor greenColor];
 [self.view addSubview:view3];
 ```
 
-#如何安装
+# 如何安装
 
 支持Pod安装，可直接将下面的代码放到Podfile中：
 
@@ -510,7 +510,7 @@ pod 'HYBImageCliped', '~> 2.0.0'
 
 或者到GITHUB直接下载【[HYBImageCliped](https://github.com/CoderJackyHuang/HYBImageCliped)】将其中的Sources目录放入到工程！
 
-#LICENSE
+# LICENSE
 
 **MIT LICENSE**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
